### PR TITLE
Rename Recipe.recipeSourceUrl to Source and update mappings/docs

### DIFF
--- a/DAOs/RecipeDao.cs
+++ b/DAOs/RecipeDao.cs
@@ -92,7 +92,7 @@ public class RecipeDao : IRecipeDao
             new NpgsqlParameter("@name", recipe.Name),
             new NpgsqlParameter("@servingAmount", recipe.ServingAmount),
             new NpgsqlParameter("@servingName", recipe.ServingName),
-            new NpgsqlParameter("@source", recipe.RecipeSourceUrl == null ? DBNull.Value : recipe.RecipeSourceUrl)
+            new NpgsqlParameter("@source", recipe.Source == null ? DBNull.Value : recipe.Source)
         };
 
         return DaoUtil.Create(_databaseConnectionSupplier.GetConnectionString(), sql, parameters);
@@ -108,7 +108,7 @@ public class RecipeDao : IRecipeDao
             new NpgsqlParameter("@name", recipe.Name),
             new NpgsqlParameter("@servingAmount", recipe.ServingAmount),
             new NpgsqlParameter("@servingName", recipe.ServingName),
-            new NpgsqlParameter("@source", recipe.RecipeSourceUrl == null ? DBNull.Value : recipe.RecipeSourceUrl),
+            new NpgsqlParameter("@source", recipe.Source == null ? DBNull.Value : recipe.Source),
             new NpgsqlParameter("@recipeId", recipe.Id)
         };
 

--- a/Models/Recipe.cs
+++ b/Models/Recipe.cs
@@ -15,7 +15,7 @@ public class Recipe {
 
     public string ServingName {get; set;}
 
-    public string? RecipeSourceUrl {get; set;}
+    public string? Source {get; set;}
 
     public DateTime? Uploaded { get; set; }
 
@@ -30,7 +30,7 @@ public class Recipe {
         this.ServingName = "ERROR";
     }
 
-    public Recipe(int Id, string Name, int ServingAmount, string ServingName, string? RecipeSourceUrl, DateTime Uploaded)
+    public Recipe(int Id, string Name, int ServingAmount, string ServingName, string? Source, DateTime Uploaded)
     {
         this.Id = Id;
         this.Name = Name;
@@ -39,7 +39,7 @@ public class Recipe {
         this.Tags = [];
         this.ServingAmount = ServingAmount;
         this.ServingName = ServingName;
-        this.RecipeSourceUrl = RecipeSourceUrl;
+        this.Source = Source;
         this.Uploaded = Uploaded;
     }
 
@@ -52,7 +52,7 @@ public class Recipe {
         Tags = recipe.Tags;
         ServingAmount = recipe.ServingAmount;
         ServingName = recipe.ServingName;
-        RecipeSourceUrl = recipe.RecipeSourceUrl;
+        Source = recipe.Source;
         Uploaded = recipe.Uploaded;
     }
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Deletes a recipe
   "tags": ["string"],
   "servingAmount": 0,
   "servingName": 0,
-  "recipeSourceUrl": "string",
+  "source": "string",
   "ingredients": "string",
   "instructions": "string"
 }
@@ -156,7 +156,7 @@ Deletes a recipe
 | `tags` | A list of string representing a list of miscellanious tags saved to the recipe |
 | `servingAmount` | The number of servings the recipe makes |
 | `servingName` | The unit of measurement for a serving of the recipe (i.e. serving, slice, sandwich) |
-| `recipeSourceUrl` | A link to the external recipe site, if there is one |
+| `source` | A link to the external recipe site, if there is one |
 | `ingredients` | The API link for the recipe's ingredients |
 | `instructions` | The API link for the recipe's instructions |
 


### PR DESCRIPTION
### Motivation
- Simplify the recipe source field name by renaming `RecipeSourceUrl` to `Source` for clearer JSON and model usage.
- Ensure database parameter mappings and documentation reflect the new property name so API payloads and persistence remain consistent.

### Description
- Renamed the model property in `Models/Recipe.cs` from `RecipeSourceUrl` to `Source` and updated the constructors and clone usage accordingly.
- Updated DAO bindings in `DAOs/RecipeDao.cs` to use `recipe.Source` for insert and update parameter values.
- Updated the public example and property table in `README.md` to use the JSON field `source` instead of `recipeSourceUrl`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b5de3c4c832b844b4bbdf713af2c)